### PR TITLE
gantho-esd-1288-modify-to-return-curl-info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Deakin/twifer",
+    "name": "ferrysyahrinal/twifer",
     "description": "Simple PHP Library for Twitter API",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
-    "name": "ferrysyahrinal/twifer",
+    "name": "Deakin/twifer",
     "description": "Simple PHP Library for Twitter API",
     "type": "library",
     "license": "MIT",
     "authors": [
+        {
+            "name": "Anthony George",
+            "email": "anthony.george@deakin.edu.au"
+        },
         {
             "name": "Ferry Syahrinal",
             "email": "ferrysyahrinal2@gmail.com"

--- a/src/API.php
+++ b/src/API.php
@@ -126,7 +126,18 @@ class API
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
         $result = curl_exec($ch);
-        return $result;
+
+        // Get the cURL info
+        $info = curl_getinfo($ch);
+
+        // Create an associative array with response and info
+        $responseData = array(
+            'response' => $result,
+            'info' => $info
+        );
+
+        // Return the response and info
+        return $responseData;
     }
 
     protected function request2($method, $req, $params = false)
@@ -149,7 +160,7 @@ class API
         }
 
         $result = $this->reqCurl($method, $url, null, $headers, $params);
-        return json_decode($result, true);
+        return $result;
     }
 
     public function request($method, $req, $params = false)
@@ -197,7 +208,7 @@ class API
         }
 
         $result = $this->reqCurl($method, $url, $params, $headers, null);
-        return json_decode($result, true);
+        return $result;
 
     }
 
@@ -211,7 +222,7 @@ class API
         $headers[] = 'Content-Type: multipart/form-data';
 
         $result = $this->reqCurl($method, $url, null, $headers, $params);
-        return json_decode($result, true);
+        return $result;
     }
 
     protected function uploadChunked($req, $params)
@@ -318,7 +329,7 @@ class API
     {
         $url = $this->apiUrl . $req;
         $result = $this->reqCurl("POST", $url, $params, null, null, true);
-        return json_decode($result, true);
+        return $result['response'];
     }
 
 }


### PR DESCRIPTION
## Overview
As part of [ESD-1288](https://jira.deakin.edu.au/jira/browse/ESD-1288), this library necessitates certain minor enhancements to facilitate its seamless integration within the current application architecture.

## Changes
- Get cURL info (curl_getinfo)
- Return an associative array containing the response data and the cURL info